### PR TITLE
Set magic ReleaseNumber for QMK-DFU

### DIFF
--- a/Bootloaders/DFU/Descriptors.c
+++ b/Bootloaders/DFU/Descriptors.c
@@ -63,7 +63,7 @@ const USB_Descriptor_Device_t DeviceDescriptor =
 
 	.VendorID               = 0x03EB,
 	.ProductID              = PRODUCT_ID_CODE,
-	.ReleaseNumber          = VERSION_BCD(0,0,0),
+	.ReleaseNumber          = VERSION_BCD(9,3,6), // Unicode Ψ in decimal
 
 	.ManufacturerStrIndex   = STRING_ID_Manufacturer,
 	.ProductStrIndex        = STRING_ID_Product,


### PR DESCRIPTION
Determining in the Toolbox whether the DFU device it's found is Atmel DFU or QMK DFU (the latter can clear the EEPROM without needing a full chip erase) is tricky. Looking at the manufacturer or product won't work, at least on Windows, as the strings presented to the Toolbox come from the driver INF files.

This gives us an easy way to tell them apart, by setting the ReleaseNumber to a magical value. Any QMK-DFU bootloaders built and flashed after this is merged (and the LUFA submodule updated) will not need QMK reflashed after clearing the EEPROM.

![](https://cdn.discordapp.com/attachments/440874198123151360/641559101276422165/unknown.png)