### PR TITLE
Made qmk-dfu wait for exit key to be released before exiting bootloader

### DIFF
--- a/Bootloaders/DFU/BootloaderDFU.c
+++ b/Bootloaders/DFU/BootloaderDFU.c
@@ -198,6 +198,11 @@ int main(void)
 	  #if (BOARD == BOARD_QMK)
 	  	bool pressed = (PIN(QMK_ESC_INPUT) & NUM(QMK_ESC_INPUT));
 		if ((DFU_State == dfuIDLE) && (keypress > 5000) && pressed) {
+			while (PIN(QMK_ESC_INPUT) & NUM(QMK_ESC_INPUT)){
+				// Wait for key to be released
+				_delay_ms(10);
+			}
+			
 			break;
 		}
 		if (pressed) {


### PR DESCRIPTION
This change waits for the user to let go of the bootloader escape key. This is to avoid the key triggering bootmagic if enabled and using the same key, as described in https://github.com/qmk/qmk_firmware/issues/8302
